### PR TITLE
Remove a gist based on it's id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ You can list the gist of a user with the following:
 ```
 gost -l <username>
 ```
+
+## Delete a gist
+
+Given you have the id of one of your gist and the right to delete it, use `-D` flag:
+
+```
+gost -D <gist_id>
+```

--- a/gist/gist.go
+++ b/gist/gist.go
@@ -93,6 +93,29 @@ func Post(baseUrl string, accessToken string, isPublic bool, filesPath []string,
 	}
 }
 
+func Delete(baseUrl string, accessToken string, gistId string) {
+
+	deleteUrl := baseUrl + "gists/" + gistId
+	if accessToken != "" {
+		deleteUrl = deleteUrl + "?access_token=" + accessToken
+	}
+	req, err := http.NewRequest("DELETE", deleteUrl, nil)
+	// handle err
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Printf("%s", err)
+		os.Exit(1)
+	} else {
+		// close connexion
+		defer resp.Body.Close()
+		if resp.StatusCode == 204 {
+			fmt.Println("Gist deleted with success")
+		} else {
+			fmt.Printf("Could not find gist %s\n", gistId)
+		}
+	}
+}
+
 func shortDate(dateString string) string {
 	date, err := time.Parse("2006-01-02T15:04:05Z07:00", dateString)
 	if err != nil {

--- a/gost.go
+++ b/gost.go
@@ -14,11 +14,13 @@ var baseUrl string = "https://api.github.com/"
 var gistDescriptionFlag = flag.String("description", "", "Description of the gist")
 var gistPrivateFlag = flag.Bool("private", false, "Set gist to private")
 var listGistsFlag = flag.String("list", "", "List gists for a user")
+var deleteGistFlag = flag.String("delete", "", "Delete a gist")
 
 func init() {
 	flag.StringVar(gistDescriptionFlag, "d", "", "Description of the gist")
 	flag.BoolVar(gistPrivateFlag, "p", false, "Set gist to private")
 	flag.StringVar(listGistsFlag, "l", "", "List gists for a user")
+	flag.StringVar(deleteGistFlag, "D", "", "Delete a gist")
 }
 
 func main() {
@@ -33,17 +35,20 @@ func main() {
 		os.Exit(2)
 	}
 
+	token := Configuration.GetToken()
+
 	if *listGistsFlag != "" {
 		username := *listGistsFlag
 		url := baseUrl + "users/" + username + "/gists"
 		Gist.List(url)
+	} else if *deleteGistFlag != "" {
+		Gist.Delete(baseUrl, token, *deleteGistFlag)
 	} else {
 		filesName := flag.Args()
 		if len(filesName) == 0 {
 			fmt.Println("No files given!")
 			os.Exit(2)
 		}
-		token := Configuration.GetToken()
 		Gist.Post(baseUrl, token, isPublic, filesName, *gistDescriptionFlag)
 	}
 }


### PR DESCRIPTION
Every gist is associated to an id which also allows to remove it.
Implement the method to do so.

REF #4
