### PR TITLE
ADD support for 2fa

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -19,13 +19,12 @@ func readConf() (token string) {
 
 	if err != nil {
 		// file does not exist
-		createConfigurationFile()
-		return string(readConf())
+		return createConfigurationFile()
 	}
 	return string(file)
 }
 
-func createConfigurationFile() {
+func createConfigurationFile() string {
 	var OAuthToken string
 
 	fmt.Println("You don't have any configuration file")
@@ -35,7 +34,12 @@ func createConfigurationFile() {
 
 	if answer == "y" || answer == "Y" || answer == "" {
 		OAuthToken = OAuth.GetToken()
+		ioutil.WriteFile(configurationFilePath, []byte(OAuthToken), 0660)
+		fmt.Printf("[configuration file written to '%s']\n", configurationFilePath)
+	} else {
+		fmt.Println("Posting an anonymous gist...")
+		fmt.Println("I'll ask you again next time!")
 	}
 
-	ioutil.WriteFile(configurationFilePath, []byte(OAuthToken), 0660)
+	return OAuthToken
 }

--- a/conf/oauth/oauth.go
+++ b/conf/oauth/oauth.go
@@ -14,41 +14,77 @@ var baseUrl string = "https://api.github.com/"
 var authorizationUrl string = baseUrl + "authorizations"
 
 func GetToken() (token string) {
+	client := &http.Client{}
+	var resp *http.Response
+	var authorizationResponseBody []byte
+
+	// json structure
 	scopes := []string{"gist"}
 	authorization := OAuthJSON.GetSingleAuth{Scopes: scopes, Note: "gost", NoteUrl: "https://github.com/MaximeD"}
-	buf, err := json.Marshal(authorization)
-
-	// encode json
+	encodedJson, err := json.Marshal(authorization)
 	if err != nil {
-		fmt.Printf("%s", err)
+		fmt.Printf("%s\n", err)
 	}
-	jsonBody := bytes.NewBuffer(buf)
 
-	// create client to handle basic auth
-	client := &http.Client{}
-	req, err := http.NewRequest("POST", authorizationUrl, jsonBody)
+	// ask for user credentials
 	username, password := getCredentials()
-	req.SetBasicAuth(username, password)
+
+	// make request
+	req := makeRequest(username, password, encodedJson)
 
 	// post json
-	resp, err := client.Do(req)
+	resp, err = client.Do(req)
 	if err != nil {
-		fmt.Printf("%s", err)
+		fmt.Printf("%s\n", err)
+		os.Exit(1)
+	}
+	authorizationResponseBody, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("%s\n", err)
 		os.Exit(1)
 	}
 
-	// close connexion
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Printf("%s", err)
-		os.Exit(1)
+	// check github response
+	if resp.StatusCode == 401 {
+		header := resp.Header
+
+		// user may have enable 2fa
+		if header.Get("X-Github-Otp") != "" {
+			fmt.Println("2-factor authentication code:")
+			var twoFA string
+			fmt.Scanln(&twoFA)
+
+			// make request
+			req := makeRequest(username, password, encodedJson)
+			req.Header.Add("X-Github-Otp", twoFA)
+
+			resp, err = client.Do(req)
+			if err != nil {
+				fmt.Printf("%s\n", err)
+				os.Exit(1)
+			}
+
+			authorizationResponseBody, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				fmt.Printf("%s\n", err)
+				os.Exit(1)
+			}
+
+			// has authorization been created?
+			if resp.StatusCode != 201 {
+				fmt.Println("Sorry but we could not authenticate you")
+				os.Exit(1)
+			}
+		} else {
+			fmt.Println("Sorry but we could not authenticate you")
+			os.Exit(1)
+		}
 	}
 
 	var jsonRes OAuthJSON.GetSingleAuthResponse
-	err = json.Unmarshal(body, &jsonRes)
+	err = json.Unmarshal(authorizationResponseBody, &jsonRes)
 	if err != nil {
-		fmt.Printf("%s", err)
+		fmt.Printf("%s\n", err)
 		os.Exit(1)
 	}
 
@@ -63,4 +99,16 @@ func getCredentials() (username string, password string) {
 	fmt.Scanln(&password)
 
 	return username, password
+}
+
+func makeRequest(username string, password string, encodedJson []byte) *http.Request {
+	jsonBody := bytes.NewBuffer(encodedJson)
+	req, err := http.NewRequest("POST", authorizationUrl, jsonBody)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		os.Exit(1)
+	}
+	req.SetBasicAuth(username, password)
+
+	return req
 }


### PR DESCRIPTION
Github users may decide to enable 2-fa authentication to have more
security. Gost was not able to tell if a user had it enabled, and even
worse, it pretended everything worked by creating an empty configuration
file.

Users can now create a token whether they have 2-fa enabled or not.

REF #11

Details:
- ADD support for 2-fa
- ADD informations when posting anonymously
- REFACTOR authentication to check response was successfull
