### PR TITLE
FIX filename json key

### DIFF
--- a/json/gist_json.go
+++ b/json/gist_json.go
@@ -48,7 +48,7 @@ type File struct {
 }
 
 type FileDetails struct {
-	FileName string `json:"file_name"`
+	FileName string `json:"filename"`
 	Type     string `json:"type"`
 	Language string `json:"language"`
 	RawUrl   string `json:"raw_url"`


### PR DESCRIPTION
The json key use for files name was `file_name` whereas gist API uses
`filename` (without underscore) as a key. As a consequence download was
not working.
Change to use the right key.

REF #16

Details:
- CHANGE `file_name` to `filename`
