### PR TITLE
FEATURE copy url to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ gost -p -d "rocking the casbah" fun.go love_gist.rb
 ```
 
 will create a private gist with description "rocking the casbah"
-with two files `fun.go` and `love_gist.rb`
+with two files `fun.go` and `love_gist.rb`.
+The resulting url will be copy to your clipboard.
 
 
 ### Private gists

--- a/gist/gist.go
+++ b/gist/gist.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/MaximeD/gost/json"
+	"github.com/MaximeD/gost/utils"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -90,6 +91,10 @@ func Post(baseUrl string, accessToken string, isPublic bool, filesPath []string,
 		os.Exit(1)
 	}
 
+  // copy url to clipboard
+  Utils.Copy(jsonRes.HtmlUrl)
+
+  // display result
 	fmt.Printf("%s\n", jsonRes.HtmlUrl)
 }
 
@@ -155,6 +160,9 @@ func Update(baseUrl string, accessToken string, filesPath []string, gistId strin
 		fmt.Printf("%s\n", err)
 		os.Exit(1)
 	}
+
+  // copy url to clipboard
+  Utils.Copy(jsonRes.HtmlUrl)
 
 	fmt.Printf("%s\n", jsonRes.HtmlUrl)
 	revisionCount := len(jsonRes.History)

--- a/utils/copy.go
+++ b/utils/copy.go
@@ -1,0 +1,23 @@
+package Utils
+
+import (
+	"os"
+	"os/exec"
+)
+
+func Copy (url string) {
+  // usual clipboards commands
+  clipboardCommands := []string{"xclip", "xsel", "pbpaste", "getclip"}
+
+  // execute each clipboard command
+  for _, command := range clipboardCommands {
+    echo := exec.Command("echo", url)
+
+    cmd := exec.Command(command)
+    cmd.Stdin, _ = echo.StdoutPipe()
+    cmd.Stdout = os.Stdout
+    cmd.Start()
+    echo.Run()
+    cmd.Wait()
+  }
+}


### PR DESCRIPTION
Once a gist has been created, it's url should be copied to clipboard.
This way a user won't have to copy it first before using it.

REF: #21

Details:
- ADD `utils/copy.go`
