### PR TITLE
USE gist url or id for all actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ To have your browser auto open on the url, use the flag `-o`.
 To update a gist:
 
 ```
-gost -u <gist_id> <files name>
+gost -u <gist_id_or_url> <files name>
 ```
 
 You can supply an optional `-d` flag to update the description of your gist.
 
 ```
-gost -u <gist_id> -d <new description> <files name>
+gost -u <gist_id_or_url> -d <new description> <files name>
 ```
 
 
@@ -80,7 +80,7 @@ gost -l <username>
 ## Download a gist
 
 ```
-gost -g <gist_id>
+gost -g <gist_id_or_url>
 ```
 
 ## Delete a gist
@@ -88,5 +88,5 @@ gost -g <gist_id>
 Given you have the id of one of your gist and the right to delete it, use `-D` flag:
 
 ```
-gost -D <gist_id>
+gost -D <gist_id_or_url>
 ```

--- a/gist/gist.go
+++ b/gist/gist.go
@@ -103,7 +103,7 @@ func Post(baseUrl string, accessToken string, isPublic bool, filesPath []string,
 	fmt.Printf("%s\n", jsonRes.HtmlUrl)
 }
 
-func Update(baseUrl string, accessToken string, filesPath []string, gistId string, description string, openBrowser bool) {
+func Update(baseUrl string, accessToken string, filesPath []string, gistUrl string, description string, openBrowser bool) {
 	files := make(map[string]GistJSON.File)
 
 	for i := 0; i < len(filesPath); i++ {
@@ -124,6 +124,8 @@ func Update(baseUrl string, accessToken string, filesPath []string, gistId strin
 		fmt.Printf("%s\n", err)
 	}
 	jsonBody := bytes.NewBuffer(buf)
+
+	gistId := getGistId(gistUrl)
 
 	// post json
 	postUrl := baseUrl + "gists/" + gistId
@@ -179,17 +181,9 @@ func Update(baseUrl string, accessToken string, filesPath []string, gistId strin
 	}
 }
 
-func Delete(baseUrl string, accessToken string, gist string) {
+func Delete(baseUrl string, accessToken string, gistUrl string) {
 
-	/*
-	   gist can be send under form
-	     https://gist.github.com/a2a510376da5ffcb93f9
-	   or
-	     a2a510376da5ffcb93f9
-	   split on '/' to retreive only id
-	*/
-	splitted := strings.Split(gist, "/")
-	gistId := splitted[len(splitted)-1]
+	gistId := getGistId(gistUrl)
 
 	deleteUrl := baseUrl + "gists/" + gistId
 	if accessToken != "" {
@@ -212,7 +206,9 @@ func Delete(baseUrl string, accessToken string, gist string) {
 	}
 }
 
-func Download(baseUrl string, accessToken string, gistId string) {
+func Download(baseUrl string, accessToken string, gistUrl string) {
+
+	gistId := getGistId(gistUrl)
 
 	downloadUrl := baseUrl + "gists/" + gistId
 	if accessToken != "" {
@@ -256,6 +252,18 @@ func shortDate(dateString string) string {
 		fmt.Println(err)
 	}
 	return date.Format("2006-01-02")
+}
+
+func getGistId(urlOrId string) string {
+	/*
+	    accepted gist format are full url:
+		     https://gist.github.com/a2a510376da5ffcb93f9
+		  or just id
+		     a2a510376da5ffcb93f9
+		   split on '/' to retreive only id
+	*/
+	splitted := strings.Split(urlOrId, "/")
+	return splitted[len(splitted)-1]
 }
 
 func printErrorMessage(resp *http.Response) {


### PR DESCRIPTION
To update or download a gist, we must pass it's id, but passing the full
url will not work.
Update methods to accept one or another.

REF: #29
